### PR TITLE
Workaround VS2019 crash

### DIFF
--- a/ErrLib/ErrLib.cpp
+++ b/ErrLib/ErrLib.cpp
@@ -48,7 +48,7 @@ BOOL IsOnVisualCpp2015OrAbove() {
 BOOL IsStackTraceDisabled() {
     // Workaround for the crash with new Visual C++ versions
     // (https://github.com/MSDN-WhiteKnight/ErrLib/issues/2)
-    return IsCPUx64 && IsDebuggerPresent() && IsOnVisualCpp2015OrAbove() && ErrLib_fDebugBuild;
+    return IsCPUx64 && IsOnVisualCpp2015OrAbove() && ErrLib_fDebugBuild;
 }
 
 /* Pointer getters*/

--- a/ErrLib/ErrLib.cpp
+++ b/ErrLib/ErrLib.cpp
@@ -400,7 +400,7 @@ ERRLIB_API void __stdcall ErrLib_PrintStack( CONTEXT* ctx , WCHAR* dest, size_t 
     HANDLE  process= NULL;
     HANDLE  thread= NULL;
     HMODULE hModule= NULL;
-    
+
     STACKFRAME64        stack;
     ULONG               frame=0;    
     DWORD64             displacement=0;

--- a/ErrLib/ErrLib.h
+++ b/ErrLib/ErrLib.h
@@ -12,13 +12,14 @@
 #include <DbgHelp.h>
 #include <Shlobj.h>
 
-
 #ifdef __cplusplus
 #include <exception>
 #include <comdef.h>
 #define ERRLIB_REFERENCE
+#define INLINE inline
 #else
 #define ERRLIB_REFERENCE &
+#define INLINE __inline
 #endif
 
 #pragma comment(lib, "advapi32.lib")
@@ -113,7 +114,7 @@ ERRLIB_API BOOL __stdcall ErrLib_SetParameter(UINT param, UINT_PTR value);
 ERRLIB_API BOOL __stdcall ErrLib_InitializeInternal();
 
 //Initializes the library. Must be called before any other functionality is used.
-BOOL inline ErrLib_Initialize(){
+BOOL INLINE ErrLib_Initialize(){
     BOOL ret = ErrLib_InitializeInternal();
 #ifdef _MSC_VER
     ErrLib_SetParameter(ERRLIB_PARAM_VISUALCPPVERSION, (UINT_PTR)_MSC_VER);

--- a/ErrLib/ErrLib.h
+++ b/ErrLib/ErrLib.h
@@ -63,6 +63,9 @@
 //Specifies that logging functions should invoke custom logging callback 
 #define ERRLIB_OUTPUT_CUSTOM 5
 
+#define ERRLIB_PARAM_VISUALCPPVERSION 100
+#define ERRLIB_PARAM_ISDEBUGBUILD 101
+
 // *** Typedefs *** 
 
 //Function pointer type used as unhandled exception callback
@@ -106,8 +109,22 @@ ERRLIB_API void __stdcall ErrLib_SetLogFilePath(LPCWSTR path);
 //Sets value for the specified configuration parameter
 ERRLIB_API BOOL __stdcall ErrLib_SetParameter(UINT param, UINT_PTR value);
 
+//Initializes the library.
+ERRLIB_API BOOL __stdcall ErrLib_InitializeInternal();
+
 //Initializes the library. Must be called before any other functionality is used.
-ERRLIB_API BOOL __stdcall ErrLib_Initialize();
+BOOL inline ErrLib_Initialize(){
+    BOOL ret = ErrLib_InitializeInternal();
+#ifdef _MSC_VER
+    ErrLib_SetParameter(ERRLIB_PARAM_VISUALCPPVERSION, (UINT_PTR)_MSC_VER);
+#endif
+
+#ifdef _DEBUG
+    ErrLib_SetParameter(ERRLIB_PARAM_ISDEBUGBUILD, (UINT_PTR)TRUE);
+#endif
+
+    return ret;
+}
 
 ERRLIB_API BOOL __stdcall ErrLib_InitTLS();
 ERRLIB_API BOOL __stdcall ErrLib_InitThread();

--- a/ErrLib/ErrLib.vcxproj
+++ b/ErrLib/ErrLib.vcxproj
@@ -32,23 +32,23 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>    
+    <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>    
+    <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>    
+    <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>    
+    <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -151,6 +151,7 @@
   <ItemGroup>
     <ClInclude Include="ErrLib.h" />
     <ClInclude Include="event.h" />
+    <ClInclude Include="vcdefs.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp">

--- a/ErrLib/ErrLib.vcxproj.filters
+++ b/ErrLib/ErrLib.vcxproj.filters
@@ -24,6 +24,9 @@
     <ClInclude Include="event.h">
       <Filter>Заголовочные файлы</Filter>
     </ClInclude>
+    <ClInclude Include="vcdefs.h">
+      <Filter>Заголовочные файлы</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ErrLib.cpp">
@@ -35,6 +38,9 @@
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="event.rc">
+      <Filter>Файлы ресурсов</Filter>
+    </ResourceCompile>
+    <ResourceCompile Include="version.rc">
       <Filter>Файлы ресурсов</Filter>
     </ResourceCompile>
   </ItemGroup>

--- a/ErrLib/vcdefs.h
+++ b/ErrLib/vcdefs.h
@@ -1,0 +1,22 @@
+//Project: ErrLib
+//Author: MSDN.WhiteKnight (https://github.com/MSDN-WhiteKnight)
+#ifndef VCDEFS_H
+#define VCDEFS_H
+
+//https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-160
+const int VISUAL_STUDIO_V2015 = 1900;
+const int VISUAL_STUDIO_V2019 = 1920;
+
+#if defined(_MSC_VER)
+const int VisualCppVersion = _MSC_VER;
+#else
+const int VisualCppVersion = 0;
+#endif
+
+#if defined(_M_AMD64)
+const BOOL IsCPUx64 = TRUE;
+#else
+const BOOL IsCPUx64 = FALSE;
+#endif
+
+#endif

--- a/pkg/ReadMe.txt
+++ b/pkg/ReadMe.txt
@@ -28,7 +28,7 @@ Notes:
 - ErrLib dynamically links to Visual C++ 2012 Standard Library (CRT) - debug or release depending on version. This means, either target machines must have Visual C++ 2012 Redistributable installed, or you must redistribute its DLLs along with your application. For any other deployment option, rebuid project from sources, changing configuration accordingly.
 - You can use ErrLib via LoadLibrary/GetProcAddress if you really want, but don't call FreeLibrary. Unloading ErrLib before process termination is not supported.
 - Enable full debug information in Visual Studio 2017 and above for complete stack traces (/DEBUG:FULL in linker options).
-- You might need to switch toolset version to VS2012 in Debug x64 builds to use SEH catch blocks.
+- Getting stack traces in exception handlers is disabled in VS2015+ x64 debug builds.
 
 Example:
 

--- a/pkg/build/ErrLib.h
+++ b/pkg/build/ErrLib.h
@@ -12,13 +12,14 @@
 #include <DbgHelp.h>
 #include <Shlobj.h>
 
-
 #ifdef __cplusplus
 #include <exception>
 #include <comdef.h>
 #define ERRLIB_REFERENCE
+#define INLINE inline
 #else
 #define ERRLIB_REFERENCE &
+#define INLINE __inline
 #endif
 
 #pragma comment(lib, "advapi32.lib")
@@ -63,6 +64,9 @@
 //Specifies that logging functions should invoke custom logging callback 
 #define ERRLIB_OUTPUT_CUSTOM 5
 
+#define ERRLIB_PARAM_VISUALCPPVERSION 100
+#define ERRLIB_PARAM_ISDEBUGBUILD 101
+
 // *** Typedefs *** 
 
 //Function pointer type used as unhandled exception callback
@@ -106,8 +110,22 @@ ERRLIB_API void __stdcall ErrLib_SetLogFilePath(LPCWSTR path);
 //Sets value for the specified configuration parameter
 ERRLIB_API BOOL __stdcall ErrLib_SetParameter(UINT param, UINT_PTR value);
 
+//Initializes the library.
+ERRLIB_API BOOL __stdcall ErrLib_InitializeInternal();
+
 //Initializes the library. Must be called before any other functionality is used.
-ERRLIB_API BOOL __stdcall ErrLib_Initialize();
+BOOL INLINE ErrLib_Initialize(){
+    BOOL ret = ErrLib_InitializeInternal();
+#ifdef _MSC_VER
+    ErrLib_SetParameter(ERRLIB_PARAM_VISUALCPPVERSION, (UINT_PTR)_MSC_VER);
+#endif
+
+#ifdef _DEBUG
+    ErrLib_SetParameter(ERRLIB_PARAM_ISDEBUGBUILD, (UINT_PTR)TRUE);
+#endif
+
+    return ret;
+}
 
 ERRLIB_API BOOL __stdcall ErrLib_InitTLS();
 ERRLIB_API BOOL __stdcall ErrLib_InitThread();

--- a/pkg/readme.md
+++ b/pkg/readme.md
@@ -26,7 +26,7 @@ Notes:
 - ErrLib dynamically links to Visual C++ 2012 Standard Library (CRT) - debug or release depending on version. This means, either target machines must have Visual C++ 2012 Redistributable installed, or you must redistribute its DLLs along with your application. For any other deployment option, rebuid project from sources, changing configuration accordingly.
 - You can use ErrLib via LoadLibrary/GetProcAddress if you really want, but don't call FreeLibrary. Unloading ErrLib before process termination is not supported.
 - Enable full debug information in Visual Studio 2017 and above for complete stack traces (/DEBUG:FULL in linker options).
-- You might need to switch toolset version to VS2012 in Debug x64 builds to use SEH catch blocks.
+- Getting stack traces in exception handlers is disabled in VS2015+ x64 debug builds.
 
 ## Example
 


### PR DESCRIPTION
Workaround VS2019 crash in debug x64 build (disable stack trace printing)

Related to #2 