### PR TITLE
Fix duplicate initialization

### DIFF
--- a/ErrLib_Tests/tests.cpp
+++ b/ErrLib_Tests/tests.cpp
@@ -113,10 +113,10 @@ namespace ErrLib_Tests
 		
         Tests() 
         {
-	    if(!initialized){
+            if(!initialized){
                 ErrLib_Initialize();
-	        initialized = true;
-	    }
+                initialized = true;
+            }
         }
 
         TEST_METHOD(Test_Errlib_Catch) 

--- a/ErrLib_Tests/tests.cpp
+++ b/ErrLib_Tests/tests.cpp
@@ -51,6 +51,7 @@ ERRLIB_STACK_TRACE StackTraceTestFunc(){
 const WCHAR logname[] = L"errlib.log";
 const int BUFFER_SIZE = 5000;
 WCHAR buf[BUFFER_SIZE]=L"";
+bool initialized = false;
 
 void WINAPI MyLoggingCallback(LPCWSTR pStr, void* pExtraInfo){
     wcscpy(buf, pStr);
@@ -112,7 +113,10 @@ namespace ErrLib_Tests
 		
         Tests() 
         {
-            ErrLib_Initialize();
+	    if(!initialized){
+                ErrLib_Initialize();
+	        initialized = true;
+	    }
         }
 
         TEST_METHOD(Test_Errlib_Catch) 


### PR DESCRIPTION
Fix duplicate ErrLib_Initialize calls that caused "SymInitialize failed with error 0x57"

Issue: #7